### PR TITLE
Switch to uglify-es fork, closes #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ fs.createReadStream('app.js')
 Create a new minify stream. Write a Javascript file or bundle to it.
 Possible `options` are:
 
- - `uglify` - An uglify module to use, defaults to [`uglify-es`](https://npmjs.com/package/uglify-es).
+ - `uglify` - An uglify module to use, defaults to [`terser`](https://npmjs.com/package/terser).
    It must have an uglify-compatible `minify()` function.
  - All other options are passed to the `minify()` function as the second parameter.
-   See the [uglify-es docs](https://github.com/mishoo/uglifyjs2#minify-options) for available options.
+   See the [terser docs](https://github.com/fabiosantoscode/terser#minify-options) for available options.
 
 `minify-stream` adds inline source maps by default. Use [`exorcist`](https://npmjs.com/package/exorcist)
 to extract source maps from the output stream into a separate file. If you don't need source maps, pass

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var duplexify = require('duplexify')
 var concat = require('concat-stream')
 var fromString = require('from2-string')
-var defaultUglify = require('@fabiosantoscode/uglify-es')
+var defaultUglify = require('terser')
 var convert = require('convert-source-map')
 var xtend = require('xtend')
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var duplexify = require('duplexify')
 var concat = require('concat-stream')
 var fromString = require('from2-string')
-var defaultUglify = require('uglify-es')
+var defaultUglify = require('@fabiosantoscode/uglify-es')
 var convert = require('convert-source-map')
 var xtend = require('xtend')
 

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "test": "standard && tape test/*.js | tap-spec"
   },
   "dependencies": {
-    "@fabiosantoscode/uglify-es": "^3.7.1",
     "concat-stream": "^1.6.0",
     "convert-source-map": "^1.5.0",
     "duplexify": "^3.5.1",
     "from2-string": "^1.1.0",
+    "terser": "^3.7.5",
     "xtend": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "test": "standard && tape test/*.js | tap-spec"
   },
   "dependencies": {
+    "@fabiosantoscode/uglify-es": "^3.7.1",
     "concat-stream": "^1.6.0",
     "convert-source-map": "^1.5.0",
     "duplexify": "^3.5.1",
     "from2-string": "^1.1.0",
-    "uglify-es": "^3.1.2",
     "xtend": "^4.0.1"
   }
 }


### PR DESCRIPTION
[Uglify-es is no longer maintained](https://github.com/mishoo/UglifyJS2/issues/2908#issuecomment-367686007), so it has been forked and many of the bugs
in uglify-es have been resolved in this fork.